### PR TITLE
update

### DIFF
--- a/docs/pages/supportedNetworks.md
+++ b/docs/pages/supportedNetworks.md
@@ -4,11 +4,6 @@ The following is the list of networks supported by the Biconomy Stack.
 Support for the network includes the deployment of Smart Account contracts
 and associated infrastructure (Bundlers / Paymasters or MEE Nodes)
 
-## Legacy SDKs Supported Chains
-
-##### [V1 Supported Chains](https://legacy-docs.biconomy.io/supportedNetworks)
-##### [V2 Supported Chains](/smartAccountsV2/supportedNetworks)
-
 ## AbstractJS & Nexus Account Supported Chains
 :::info
 Click the table headers to view the real-time list of deployed contracts on [contractscan](https://contractscan.xyz/).
@@ -48,3 +43,50 @@ Other chains: [0x00000072a5F551D6E80b2f6ad4fB256A27841Bbc](https://contractscan.
 > 💡 This is the list of chains for Nexus (EntryPoint v0.7.0). You can find the list of supported networks for our Bundlers & Paymasters using EntryPoint v0.6.0 [here](/smartAccountsV2/supportedNetworks).
 
 Need support for a new chain? Contact us [here](https://forms.gle/nycUAs3Fwyzz772w7).
+
+## V2 Supported Networks
+
+Networks supported
+
+|Network | Testnet | Mainnet |   
+| --- | --- | --- |
+|Ethereum | ✅ | ✅ |        
+|Polygon | ✅ | ✅ |  
+|BSC | ✅ | ✅ |  
+|Polygon zkEVM  | ✅ | ✅ |  
+|Arbitrum One  | ✅  | ✅ |  
+|Arbitrum Nova  | ✅ | ✅ |  
+|Optimism  | ✅ (Sepolia)| ✅ |  
+|Avalanche  | ✅ | ✅ | 
+|Base | ✅ | ✅ |    
+|Linea | ✅ | ✅ |    
+|Chiliz | ✅ | ✅ |    
+|Astar | ✅ | ✅ |    
+|opBNB | ✅ | ✅ |  
+|Manta | ✅ | ✅ |    
+|Core | ✅ | ✅ |    
+|Combo | ✅ | ✅ |  
+|Mantle | ✅ (Sepolia) | ✅ |  
+|Blast | ✅ | ✅ | 
+|Zeroone | ✅ | ✅ | 
+|Scroll | ✅ | ✅ | 
+|Bera | ✅ |  | 
+|Zetachain | ✅ | ✅ | 
+|Gold (L3 on Base) |  | ✅ | 
+|Degenchain |  | ✅ | 
+|Olive | ✅ |  | 
+|Polygon zkEVM Cardona | ✅ |  | 
+|Gnosis | ✅ | ✅ | 
+|X Layer| ✅ | ✅ | 
+|Tangle| ✅ | ✅ | 
+|Taiko|  | ✅ | 
+|Morph| ✅ | ✅ | 
+|Sei| ✅ (Devnet) | ✅ | 
+|Boba| ✅ | ✅ |
+|5irechain| ✅ | ✅ |
+|Metal L2| ✅ | ✅ |
+|Lisk| ✅ | ✅ |
+
+## Legacy SDKs Supported Chains
+
+##### [V1 Supported Chains](https://legacy-docs.biconomy.io/supportedNetworks)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `supportedNetworks.md` documentation to include a comprehensive list of networks supported by the Biconomy Stack, detailing both testnet and mainnet availability. It also introduces a new section for V2 supported networks.

### Detailed summary
- Added introductory text about supported networks and infrastructure.
- Included a new section titled `V2 Supported Networks` with a detailed table listing various networks, their testnet, and mainnet support.
- Added a link to `V1 Supported Chains` for legacy SDKs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->