### PR TITLE
Nexus 1.0.2

### DIFF
--- a/docs/pages/contractsAndAudits.md
+++ b/docs/pages/contractsAndAudits.md
@@ -1,5 +1,14 @@
 # Production Contracts
 
+## Nexus v1.0.2 Production Contracts
+| Name    | Address    | 
+|-------------|-------------|
+| Nexus implementation  | `0x000000aC74357BFEa72BBD0781833631F732cf19`  |
+| K1 Validator  | `0x0000002D6DB27c52E3C11c1Cf24072004AC75cBa`  | 
+| K1 Validator Factory  | `0x2828A0E0f36d8d8BeAE95F00E2BbF235e4230fAc`  | 
+| Account Factory  | `0x000000c3A93d2c5E02Cb053AC675665b1c4217F9`  |
+| Bootstrap  | `0x879fa30248eeb693dcCE3eA94a743622170a3658`  |
+
 ## Nexus v1.0.1 Production Contracts
 | Name    | Address    | 
 |-------------|-------------|

--- a/docs/pages/supportedNetworks.md
+++ b/docs/pages/supportedNetworks.md
@@ -5,32 +5,34 @@ Click the table headers to view the real-time list of deployed contracts on [con
 :::
 
 
-| Network                      | Bundler | Sponsorship PM (Infra) | Token PM (Infra) | Sponsorship PM Contracts | [Token PM Contract](https://contractscan.xyz/contract/0x00000000301515A5410e0d768aF4f53c416edf19) | [Nexus Contract](https://contractscan.xyz/contract/0x0000002D6DB27c52E3C11c1Cf24072004AC75cBa) |
+| Network                      | Bundler | Sponsorship PM (Infra) | Token PM (Infra) | Sponsorship PM Contracts | [Token PM Contract](https://contractscan.xyz/contract/0x00000000301515A5410e0d768aF4f53c416edf19) | [Nexus Contracts] |
 |-----------------------------|---------|----------------------|-----------------|----------------------|-----------------|-----------------|
-| Ethereum Mainnet            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Ethereum Sepolia            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Base Mainnet                | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Base Testnet                | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| OP Mainnet                  | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| OP Sepolia Testnet          | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Scroll Mainnet              | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Scroll Sepolia Testnet      | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Arbitrum Mainnet            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Arbitrum Sepolia Testnet    | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Binance Smart Chain Mainnet | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Binance Smart Chain Testnet | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Polygon Mainnet             | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Polygon Amoy Testnet        | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅              |
-| Gnosis Mainnet              | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Gnosis Chiado Testnet       | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅              |
-| Sonic Mainnet               | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Sonic Testnet               | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅              |
-| Blast Mainnet               | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅              |
-| Blast Sepolia               | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅              |
-| IOTA Mainnet                | ⏳      | ⏳                   | ⏳              | ✅                   | ✅              | ✅              |
-| Monad Testnet               | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅              |
+| Ethereum Mainnet            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Ethereum Sepolia            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Base Mainnet                | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Base Sepolia                | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| OP Mainnet                  | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| OP Sepolia Testnet          | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Scroll Mainnet              | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Scroll Sepolia Testnet      | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Arbitrum Mainnet            | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Arbitrum Sepolia Testnet    | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Binance Smart Chain Mainnet | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Binance Smart Chain Testnet | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Polygon Mainnet             | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Polygon Amoy Testnet        | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅ (v1.0.2)              |
+| Gnosis Mainnet              | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Gnosis Chiado Testnet       | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅ (v1.0.2)              |
+| Sonic Mainnet               | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Sonic Blaze Testnet         | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅ (v1.0.2)              |
+| Blast Mainnet               | ✅      | ✅                   | ✅              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Blast Sepolia               | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅ (v1.0.2)              |
+| IOTA Mainnet                | ⏳      | ⏳                   | ⏳              | ✅                   | ✅              | ✅ (v1.0.2)              |
+| Monad Testnet               | ✅      | ✅                   | ❌              | ✅                   | ❌              | ✅ (v1.0.2)              |
 
 *PM = Paymaster
+*⏳ = Coming Soon
+*❌ = Not Supported
 
 Sponsorship PM Contract has two addresses: 
 Base and OP: [0x0000006087310897e0BFfcb3f0Ed3704f7146852](https://contractscan.xyz/contract/0x0000006087310897e0BFfcb3f0Ed3704f7146852)


### PR DESCRIPTION
Add addresses for Nexus 1.0.2

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the documentation for `Nexus` contracts and supported networks, introducing new contract addresses for version `v1.0.2` and enhancing the network support table with additional details.

### Detailed summary
- Added a new section for `Nexus v1.0.2 Production Contracts` with contract names and addresses.
- Updated the supported networks table to include version `v1.0.2` for various networks.
- Introduced new entries for `Base Sepolia` and `Sonic Blaze Testnet`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->