### PR TITLE
change bootstrap address

### DIFF
--- a/docs/pages/contractsAndAudits.md
+++ b/docs/pages/contractsAndAudits.md
@@ -14,7 +14,7 @@
 | Name    | Address    | 
 |-------------|-------------|
 | Nexus Implementation v1.2.0 | `0x000000004F43C49e93C970E84001853a70923B03`  |
-| Nexus Bootstrap v1.2.0 | `0x00000000fc7930C6F28401804b9606669A015Ff7`  |
+| Nexus Bootstrap v1.2.0 | `0x00000000D3254452a909E4eeD47455Af7E27C289`  |
 | Nexus Account Factory | `0x000000001D1D5004a02bAfAb9de2D6CE5b7B13de`  |
 
 [GitHub](https://github.com/bcnmy/nexus/releases/tag/v1.2.0)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `Nexus Bootstrap` address in the documentation for version `1.2.0`. 

### Detailed summary
- Updated the `Nexus Bootstrap v1.2.0` address from `0x00000000fc7930C6F28401804b9606669A015Ff7` to `0x00000000D3254452a909E4eeD47455Af7E27C289`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->