### PR TITLE
add apechain

### DIFF
--- a/docs/pages/supportedNetworks.md
+++ b/docs/pages/supportedNetworks.md
@@ -24,6 +24,8 @@
 | Gnosis Chiado Testnet       | ✅        | v1.2.0, v1.0.2   | ⏳                       |
 | Avalanche Mainnet           | ✅        | v1.2.0, v1.0.2   | ⏳                       |
 | Avalanche Fuji Testnet      | ✅        | v1.2.0, v1.0.2   | ⏳                       |
+| Apechain                    | ✅        | v1.2.0           | ⏳                       |
+| Apechain Curtis Testnet     | ✅        | v1.2.0           | ⏳                       |  
 
 For contracts addresses and audit reports, see [here](https://docs.biconomy.io/contractsAndAudits).
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `supportedNetworks.md` documentation to include additional networks, specifically `Apechain` and `Apechain Curtis Testnet`, along with their supported versions.

### Detailed summary
- Added `Apechain` to the list of supported networks with version `v1.2.0`.
- Added `Apechain Curtis Testnet` to the list of supported networks with version `v1.2.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->