### PR TITLE
fix v2 to Nexus upgrade docs

### DIFF
--- a/docs/pages/migrations/v2ToNexus.md
+++ b/docs/pages/migrations/v2ToNexus.md
@@ -64,8 +64,9 @@ const config = {
   paymasterApiKey: "YOUR_PAYMASTER_API_KEY", // Replace with your Paymaster API key
   
   // Nexus contract addresses
-  nexusImplementationAddress: "0x000000008761E87F023f65c49DC9cb1C7EdFEaaf",
-  nexusBootstrapAddress: "0x000000F5b753Fdd20C5CA2D7c1210b3Ab1EA5903",
+  // Use the latest addresses from here https://docs.biconomy.io/contracts-and-audits/
+  nexusImplementationAddress: "",
+  nexusBootstrapAddress: "",
   emptyHookAddress: "0x0000000000000000000000000000000000000001"
 };
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the Nexus contract addresses, removing specific addresses and replacing them with a note to refer to the latest addresses from an external source.

### Detailed summary
- Removed specific values for `nexusImplementationAddress` and `nexusBootstrapAddress`.
- Added a comment to refer to the latest addresses from the Biconomy documentation.
- Kept the `emptyHookAddress` unchanged.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->